### PR TITLE
preliminary fix in `makedoc.g`

### DIFF
--- a/makedoc.g
+++ b/makedoc.g
@@ -21,7 +21,7 @@ if fail = LoadPackage("AutoDoc", ">= 2019.07.03") then
     ErrorNoReturn("AutoDoc 2019.07.03 or newer is required");
 fi;
 
-Read("regen_doc.g");
+Read(Filename(DirectoryCurrent(), "regen_doc.g"));
 
 scan_dirs := [
     "doc",


### PR DESCRIPTION
Make sure that the correct path of `regen_doc.g` is used when PackageManager builds the documentation.

(This change can be undone as soon as the fix from gap-packages/PackageManager/pull/124 can be assumed.)